### PR TITLE
0.3.0: 24th December 2023

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,35 @@
 name: Rust
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+	push:
+		branches: [ "main" ]
+	pull_request:
+		branches: [ "main" ]
 
 env:
-  CARGO_TERM_COLOR: always
+	CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+	build-linux:
+		runs-on: ubuntu-latest
+		steps:
+			- uses: actions/checkout@v3
+			- name: Check on Linux
+				run: cargo check --verbose
+			- name: Build on Linux
+				run: cargo build --verbose
+			- name: Run tests on Linux
+				run: cargo test --verbose
 
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+	build-windows:
+		runs-on: windows-latest
+		steps:
+			- uses: actions/checkout@v3
+			- name: Set up Rust on Windows
+				uses: actions/setup-rust@v1
+			- name: Check on Windows
+				run: cargo check --verbose
+			- name: Build on Windows
+				run: cargo build --verbose
+			- name: Run tests on Windows
+				run: cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## \[Unreleased\]
 
+### Added
+
+  - Color converting to HSL, LCh, and RGB.
+  - TOML configuration (optional):
+    - Color distance
+    - Benchmark
+    - Midpoints
+
+## \[0.3.0\] - 2023-12-24
+
+### Added
+
+  - Added the option to benchmark the color blending.
+  - Added the possibility to calculate the difference between two hexadecimal
+    colors.
+
+### Changed
+
+  - Updated dependencies in `Cargo.lock` (`anyhow`, `libc`, `proc-macro2`, `rayon`).
+  - The GitHub Actions workflows now check, test and build on Windows and Linux.
+  - Bumped version in `Cargo.toml` (0.2.0 -\> 0.3.0).
+
+### Removed
+
+  - Removed the `-w, --write` flag, as the `-o, --output` flag is more concise.
+
 ## \[0.2.0\] - 2023-12-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "atty"
@@ -29,10 +29,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -54,8 +66,46 @@ name = "color-blender-rs"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "rayon",
  "structopt",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "heck"
@@ -83,9 +133,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "proc-macro-error"
@@ -113,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -127,6 +177,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "color-blender-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color-blender-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 structopt = "0.3"
 anyhow = "1.0"
+rayon = "1.8"

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ $ cargo build --release
 ## Usage
 
 ```console
-$ ./color-blender-rs <first-color> <second-color> [-m <midpoints> --write <should-write> -o <output-file>]
+$ ./color-blender-rs <first-color> <second-color> [-m <midpoints> -o <output-file> --benchmark>]
 ```
 
   - `<start color>`: The starting hexadecimal color (e.g., "\#ff0000" for red).
   - `<end color>`: The ending hexadecimal color (e.g., "\#00ff00" for green).
   - `<midpoints>`: The number of midpoints to generate between the start and end colors. The default is 10.
-  - `<should-write>`: Specify if you want to write the blended colors to a file. If you won't, it will display the colors in the console.
-  - `<output-file>`: Self-explanatory.
+  - `<output-file>`: The output file to write the blended colors. (default: print colors to console).
+  - `<benchmark>`: Gets the time it takes to blend the colors in microseconds.
 
 ### Examples
 
@@ -47,7 +47,7 @@ $ ./color-blender-rs "#ff0000" "#00ff00" 5
 Blend 10 midpoints between blue (\#0000ff) and yellow (\#ffff00) and write the output to default (output.txt):
 
 ```console
-$ ./color-blender-rs "#0000ff" "#ffff00" 10 --write
+$ ./color-blender-rs "#0000ff" "#ffff00" 10 -o output.txt
 ```
 
 ## Contributing

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,17 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
 use std::{
     fs::File,
     io::{BufWriter, Write},
     path::PathBuf,
+    time::Instant,
 };
 use structopt::StructOpt;
 
 pub struct Blending;
 mod color_blender;
-use color_blender::ColorBlender;
+use color_blender::{ColorBlender, ColorConverter};
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt)]
 #[structopt(name = "color-blender-rs", about = "A color blender, written in Rust.")]
 struct Opt {
     #[structopt(help = "The first color in hex format")]
@@ -22,60 +23,116 @@ struct Opt {
     #[structopt(short, long, default_value = "10", help = "Number of midpoints")]
     midpoints: usize,
 
-    #[structopt(short, long, help = "Output file path", default_value = "output.txt")]
-    output: PathBuf,
+    #[structopt(short, long, help = "Output file path")]
+    output: Option<PathBuf>,
 
-    #[structopt(
-        short = "w",
-        long = "write",
-        help = "Write the blended colors to a file"
-    )]
-    should_write: bool,
+    #[structopt(short, long, help = "Calculates the sRGB distance between two colors")]
+    distance: bool,
+
+    #[structopt(short, long, help = "Prints the time it took to blend colors")]
+    benchmark: bool,
 }
+
 
 fn main() -> Result<()> {
     let opt = Opt::from_args();
 
-    let blender = ColorBlender::new(opt.first_color, opt.second_color, opt.midpoints);
-    let colors = blender.blend_colors();
+    let first_color = opt.first_color.to_string();
+    let second_color = opt.second_color.to_string();
 
-    let file = File::create(opt.output)?;
-    let writer = BufWriter::new(file);
+    let blender = ColorBlender::new(first_color, second_color, opt.midpoints);
+    let mut colors: Vec<String> = Vec::new();
 
-    match opt.should_write {
-        true => match Blending::write(colors, writer) {
-            Ok(_) => {
-                return Ok(());
+    if opt.benchmark {
+        let num_iterations = &opt.midpoints;
+
+        let start_time = Instant::now();
+        colors = blender.blend_colors();
+        let end_time = Instant::now();
+
+        let elapsed_time = end_time - start_time;
+        let avg_time_per_iteration = (elapsed_time / *num_iterations as u32).as_nanos();
+
+        for color in &colors {
+            println!("{}", color);
+        }
+
+        println!("Elapsed time: {}μs", elapsed_time.as_micros());
+        println!("Average time per iteration: {}ns", avg_time_per_iteration);
+        return Ok(());
+    }
+
+
+    if opt.distance {
+        let firstcolors = ColorConverter::hex_to_rgb(&opt.first_color)?;
+        let lastcolors = ColorConverter::hex_to_rgb(&opt.second_color)?;
+
+        let first_colors = match firstcolors {
+            (r, g, b) => (r as f32, g as f32, b as f32),
+        };
+
+        let last_colors = match lastcolors {
+            (r, g, b) => (r as f32, g as f32, b as f32),
+        };
+
+        let distance = color_difference(first_colors, last_colors);
+
+        println!("Distance: {distance}");
+
+        if distance == 0.0 {
+            println!("The colors are identical.");
+        } else if 0.0 < distance && distance < 0.1 {
+            println!("There is a difference in color, but it's not noticeable.");
+        } else if 0.1 < distance && distance < 0.5 {
+            println!("There is a noticeable but not significant difference in color");
+        } else if 0.5 < distance && distance < 1.0 {
+            println!("There is a potentially significant and very noticeable color difference.");
+        } else if distance > 1.0 {
+            println!("There is a significant difference in the colors.");
+        }
+
+        return Ok(());
+    }
+
+    match opt.output {
+        Some(path) => {
+            let file = File::create(&path)?;
+            let writer = BufWriter::new(file);
+            return write_colors(colors, writer).map_err(|err| {
+                Error::msg(format!(
+                    "Error while writing file to '{}': {}",
+                    path.display(),
+                    err
+                ))
+            });
+        }
+        None => {
+            colors = blender.blend_colors();
+            for color in colors {
+                println!("{}", color);
             }
-            Err(err) => {
-                let error_msg = format!("Error: {}", err);
-                return Err(anyhow::Error::msg(error_msg));
-            }
-        },
-        false => {
-            Blending::print(colors);
         }
     };
+    Ok(())
+}
+
+fn write_colors<W: Write>(blended_colors: Vec<String>, mut writer: W) -> Result<()> {
+    let mut buffered_writer = BufWriter::new(&mut writer);
+
+    for color in &blended_colors {
+        writeln!(buffered_writer, "{}", color)?;
+    }
+
+    buffered_writer.flush()?;
+    println!("Data written successfully.");
 
     Ok(())
 }
 
-impl Blending {
-    pub fn write<W: Write>(blended_colors: Vec<String>, mut writer: W) -> Result<()> {
-        let mut buffered_writer = BufWriter::new(&mut writer);
+fn color_difference(first_color: (f32, f32, f32), second_color: (f32, f32, f32)) -> f32 {
+        let difference = ((second_color.0 - first_color.0) / 255.0).powf(2.0)
+            + ((second_color.1 - first_color.1) / 255.0).powf(2.0)
+            + ((second_color.2 - first_color.2) / 255.0).powf(2.0);
 
-        for color in &blended_colors {
-            writeln!(buffered_writer, "{}", color)?;
-        }
-
-        buffered_writer.flush()?;
-        println!("Data written successfully.");
-
-        Ok(())
-    }
-    pub fn print(blended_colors: Vec<String>) {
-        for color in blended_colors {
-            println!("{}", color);
-        }
-    }
+        difference.sqrt()
 }


### PR DESCRIPTION
## \[0.3.0\] - 2023-12-24

### Added

  - Added the option to benchmark the color blending.
  - Added the possibility to calculate the difference between two hexadecimal
    colors.

### Changed

  - Updated dependencies in `Cargo.lock` (`anyhow`, `libc`, `proc-macro2`, `rayon`).
  - The GitHub Actions workflows now check, test and build on Windows and Linux.
  - Bumped version in `Cargo.toml` (0.2.0 -\> 0.3.0).

### Removed

  - Removed the `-w, --write` flag, as the `-o, --output` flag is more concise.
